### PR TITLE
Change imdb score display

### DIFF
--- a/app/javascript/controllers/hide_score_slider_controller.js
+++ b/app/javascript/controllers/hide_score_slider_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 
 export default class extends Controller {
-  static targets = [ "percentageQuestion", "numericQuestion" ]
+  static targets = [ "percentageQuestion", "numericQuestion", "output", "scoreRange" ]
 
   connect() {
     // console.log("The 'hide slider' controller is now loaded!")
@@ -12,15 +12,14 @@ export default class extends Controller {
     if (event.currentTarget.value === "metacritic" || event.currentTarget.value === "imdb" || event.currentTarget.value === "rotten_tomatoes") {
       console.log(event.currentTarget.value)
       this.percentageQuestionTarget.classList.remove("hidden");
+      this.outputTarget.innerHTML = `${this.scoreRangeTarget.value}%`;
       // this.numericQuestionTarget.classList.add("hidden");
     }
 
-    // if (event.currentTarget.value === "imdb") {
-    //   console.log("IMDB selected")
-    //   this.numericQuestionTarget.classList.remove("hidden");
-    //   this.percentageQuestionTarget.classList.add("hidden");
-
-    // }
+    if (event.currentTarget.value === "imdb") {
+      console.log("IMDB selected")
+      this.outputTarget.innerHTML = `${this.scoreRangeTarget.value / 10}`;
+    }
 
     if (event.currentTarget.value === "no_site") {
       console.log("No site selected")

--- a/app/javascript/controllers/hide_score_slider_controller.js
+++ b/app/javascript/controllers/hide_score_slider_controller.js
@@ -10,21 +10,21 @@ export default class extends Controller {
 
   toggleSlider(event) {
     if (event.currentTarget.value === "metacritic" || event.currentTarget.value === "imdb" || event.currentTarget.value === "rotten_tomatoes") {
-      console.log("Metacritic/RT selected")
+      console.log(event.currentTarget.value)
       this.percentageQuestionTarget.classList.remove("hidden");
-      this.numericQuestionTarget.classList.add("hidden");
+      // this.numericQuestionTarget.classList.add("hidden");
     }
 
-    if (event.currentTarget.value === "imdb") {
-      console.log("IMDB selected")
-      this.numericQuestionTarget.classList.remove("hidden");
-      this.percentageQuestionTarget.classList.add("hidden");
+    // if (event.currentTarget.value === "imdb") {
+    //   console.log("IMDB selected")
+    //   this.numericQuestionTarget.classList.remove("hidden");
+    //   this.percentageQuestionTarget.classList.add("hidden");
 
-    }
+    // }
 
     if (event.currentTarget.value === "no_site") {
       console.log("No site selected")
-      this.numericQuestionTarget.classList.add("hidden");
+      // this.numericQuestionTarget.classList.add("hidden");
       this.percentageQuestionTarget.classList.add("hidden");
     }
   }

--- a/app/javascript/controllers/range_slider_value_controller.js
+++ b/app/javascript/controllers/range_slider_value_controller.js
@@ -5,26 +5,25 @@ import { Controller } from "@hotwired/stimulus"
 
 
 export default class extends Controller {
-  static targets = [ "valueOutput", "scoreRange", "numericOutput", "percentageOutput","percentageScoreRange", "numericScoreRange" ]
+  static targets = [ "platform", "valueOutput", "scoreRange", "numericOutput", "percentageOutput","percentageScoreRange", "numericScoreRange" ]
 
   connect() {
     // console.log("The 'range slider value' controller is now loaded!")
   }
 
   showScore(event) {
-  if (event.currentTarget === this.percentageScoreRangeTarget) {
+    let platform = document.querySelector('input[class="critic-tag-selector"]:checked').value;
+  if (platform === "rotten_tomatoes" || platform === "metacritic")  {
       this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value}%`
   }
-
-  if (event.currentTarget === this.numericScoreRangeTarget) {
-    this.numericOutputTarget.innerHTML = `${this.numericScoreRangeTarget.value}`
+  if (platform === "imdb") {
+    this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value / 10}`
 }
 
     }
 
   showTime(event) {
-    // console.log(event)
-    if (this.scoreRangeTarget.value > 179) {
+      if (this.scoreRangeTarget.value > 179) {
       this.valueOutputTarget.innerHTML = "No limit";
     } else {
       this.valueOutputTarget.innerHTML = `${this.scoreRangeTarget.value} mins`

--- a/app/views/movies/search.html.erb
+++ b/app/views/movies/search.html.erb
@@ -84,7 +84,7 @@
             <div class="options">
               <%= form.collection_radio_buttons :review_site, [['IMDb', 'imdb'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['Metacritic', 'metacritic'], ['No Site', 'no_site']], :last, :first, include_hidden: false, checked: ['No Site', 'no_site'] do |b| %>
                 <div class="tag-item">
-                  <%= b.radio_button class: "critic-tag-selector", data: { action: "input->hide-score-slider#toggleSlider" } %>
+                  <%= b.radio_button class: "critic-tag-selector", data: { action: "input->hide-score-slider#toggleSlider", target: "range-slider-value.platform"} %>
                   <%= b.label  %>
                 </div>
               <% end %>
@@ -114,14 +114,14 @@
                 </div>
 
 
-              <!-- NUMERIC (IMDB) -->
+              <!-- NUMERIC (IMDB)
                 <div class="question-block hidden" data-hide-score-slider-target="numericQuestion">
                   <h5>Pick a minimum score for your film</h5>
                   <div class="options slidecontainer">
                     <%= form.range_field :score,  min: "0", max: "10", class: "slider", value: 5, step: 1, data: { action: "input->range-slider-value#showScore", range_slider_value_target: "numericScoreRange"}%>
                     <p><span data-range-slider-value-target="numericOutput">5</span></p>
                   </div>
-                </div>
+                </div>-->
 
             <!-- <%= form.radio_button :score, "60" %>
             <%= form.label :'60', "60" %>

--- a/app/views/movies/search.html.erb
+++ b/app/views/movies/search.html.erb
@@ -84,7 +84,7 @@
             <div class="options">
               <%= form.collection_radio_buttons :review_site, [['IMDb', 'imdb'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['Metacritic', 'metacritic'], ['No Site', 'no_site']], :last, :first, include_hidden: false, checked: ['No Site', 'no_site'] do |b| %>
                 <div class="tag-item">
-                  <%= b.radio_button class: "critic-tag-selector", data: { action: "input->hide-score-slider#toggleSlider", target: "range-slider-value.platform"} %>
+                  <%= b.radio_button class: "critic-tag-selector", data: { action: "input->hide-score-slider#toggleSlider", range_slider_value_target: "platform"} %>
                   <%= b.label  %>
                 </div>
               <% end %>
@@ -108,8 +108,8 @@
                 <div class="question-block hidden" data-hide-score-slider-target="percentageQuestion">
                   <h5>Pick a minimum score for your film</h5>
                   <div class="options slidecontainer">
-                    <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: 50, step: 5, data: { action: "input->range-slider-value#showScore", range_slider_value_target: "percentageScoreRange"}%>
-                    <p><span data-range-slider-value-target="percentageOutput"></span></p>
+                    <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: 50, step: 5, data: { action: "input->range-slider-value#showScore", range_slider_value_target: "percentageScoreRange", hide_score_slider_target: "scoreRange"}%>
+                    <p><span data-hide-score-slider-target="output" data-range-slider-value-target="percentageOutput"></span></p>
                   </div>
                 </div>
 


### PR DESCRIPTION
I have amended the stimulus controllers for the critic score searching.

There is only one score field that is passed through as params.  How this displays on the view under the slider depends on which review site radio button is selected.  If it's Metacritic or Rotten Tomatoes, then it displays the number with a percentage sign.  If it's IMDb, then it's the value divided by 10. 