### PR TITLE
Fix scroll review

### DIFF
--- a/app/javascript/controllers/range_slider_value_controller.js
+++ b/app/javascript/controllers/range_slider_value_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus"
 
 
 export default class extends Controller {
-  static targets = [ "platform", "valueOutput", "scoreRange", "numericOutput", "percentageOutput","percentageScoreRange", "numericScoreRange" ]
+  static targets = [ "platform", "valueOutput", "scoreRange", "numericOutput", "percentageOutput","percentageScoreRange", "numericScoreRange", "site"]
 
   connect() {
     // console.log("The 'range slider value' controller is now loaded!")
@@ -21,6 +21,19 @@ export default class extends Controller {
 }
 
     }
+
+    showScoreFilter(event) {
+      let input = document.querySelectorAll('#review_site')[1];
+      let platform = input.options[input.selectedIndex].value;
+      console.log(platform)
+    if (platform === "rotten_tomatoes" || platform === "metacritic")  {
+        this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value}%`
+    }
+    if (platform === "imdb") {
+      this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value / 10}`
+  }
+
+      }
 
   showTime(event) {
       if (this.scoreRangeTarget.value > 179) {

--- a/app/javascript/controllers/range_slider_value_controller.js
+++ b/app/javascript/controllers/range_slider_value_controller.js
@@ -9,6 +9,17 @@ export default class extends Controller {
 
   connect() {
     // console.log("The 'range slider value' controller is now loaded!")
+    if (document.querySelectorAll('#review_site')[1]) {
+      let input = document.querySelectorAll('#review_site')[1];
+      let platform = input.options[input.selectedIndex].value;
+      if (platform === "rotten_tomatoes" || platform === "metacritic")  {
+            this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value}%`
+        }
+        if (platform === "imdb") {
+          this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value / 10}`
+      }
+    }
+
   }
 
   showScore(event) {
@@ -25,7 +36,7 @@ export default class extends Controller {
     showScoreFilter(event) {
       let input = document.querySelectorAll('#review_site')[1];
       let platform = input.options[input.selectedIndex].value;
-      console.log(platform)
+
     if (platform === "rotten_tomatoes" || platform === "metacritic")  {
         this.percentageOutputTarget.innerHTML = `${this.percentageScoreRangeTarget.value}%`
     }

--- a/app/views/movies/search_results.html.erb
+++ b/app/views/movies/search_results.html.erb
@@ -170,7 +170,7 @@
 
         <p>Time Limit</p>
         <div class="options slidecontainer" data-controller="range-slider-value">
-            <%= form.range_field :time, min: "90", max: "180", class: "slider", value: params[:time], step: 5, data: { action: "change->range-slider-value#showTime", range_slider_value_target: "scoreRange"}%>
+            <%= form.range_field :time, min: "90", max: "180", class: "slider", value: params[:time], step: 5, data: { action: "input->range-slider-value#showTime", range_slider_value_target: "scoreRange"}%>
             <p><span data-range-slider-value-target="valueOutput"><%= params[:time] %> mins</span></p>
         </div>
         <p class="mb-0">Date Range</p>

--- a/app/views/movies/search_results.html.erb
+++ b/app/views/movies/search_results.html.erb
@@ -162,8 +162,8 @@
         <p> Review Score</p>
         <%= form.select :review_site, [['Select Review Site', 'no_site'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['IMDb', 'imdb'], ['Metacritic', 'metacritic']], class: 'form-select' %>
         <div class="options slidecontainer" data-controller="range-slider-value">
-          <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: 50, step: 5, data: { action: "input->range-slider-value#showScore", range_slider_value_target: "percentageScoreRange"}%>
-          <p><span data-range-slider-value-target="percentageOutput">50%</span></p>
+          <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: params[:score], step: 5, data: { action: "input->range-slider-value#showScore", range_slider_value_target: "percentageScoreRange"}%>
+          <p><span data-range-slider-value-target="percentageOutput"><%=params[:score]%></span></p>
         </div>
         <p>Time Limit</p>
         <div class="options slidecontainer" data-controller="range-slider-value">

--- a/app/views/movies/search_results.html.erb
+++ b/app/views/movies/search_results.html.erb
@@ -161,10 +161,10 @@
         <%= form.hidden_field :review_site, value: params[:review_site] %>
         <p> Review Score</p>
         <div data-controller="range-slider-value">
-          <%= form.select :review_site, [['Select Review Site', 'no_site'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['IMDb', 'imdb'], ['Metacritic', 'metacritic']], value: params[:review_site],class: 'form-select', data: {range_slider_value_target: "site"} %>
+          <%= form.select :review_site, [['Select Review Site', 'no_site'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['IMDb', 'imdb'], ['Metacritic', 'metacritic']], selected: params[:review_site], class: 'form-select', data: {range_slider_value_target: "site"} %>
           <div class="options slidecontainer" >
             <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: params[:score], step: 5, data: { action: "input->range-slider-value#showScoreFilter", range_slider_value_target: "percentageScoreRange"}%>
-            <p><span data-range-slider-value-target="percentageOutput"><%=params[:score]%></span></p>
+            <p><span data-range-slider-value-target="percentageOutput" class="score"><%=params[:score]%></span></p>
           </div>
         </div>
 

--- a/app/views/movies/search_results.html.erb
+++ b/app/views/movies/search_results.html.erb
@@ -160,11 +160,14 @@
         <%= form.hidden_field :platform_ids, value: params[:platform_ids] %>
         <%= form.hidden_field :review_site, value: params[:review_site] %>
         <p> Review Score</p>
-        <%= form.select :review_site, [['Select Review Site', 'no_site'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['IMDb', 'imdb'], ['Metacritic', 'metacritic']], class: 'form-select' %>
-        <div class="options slidecontainer" data-controller="range-slider-value">
-          <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: params[:score], step: 5, data: { action: "input->range-slider-value#showScore", range_slider_value_target: "percentageScoreRange"}%>
-          <p><span data-range-slider-value-target="percentageOutput"><%=params[:score]%></span></p>
+        <div data-controller="range-slider-value">
+          <%= form.select :review_site, [['Select Review Site', 'no_site'], ['Rotten Tomatoes', 'rotten_tomatoes'], ['IMDb', 'imdb'], ['Metacritic', 'metacritic']], value: params[:review_site],class: 'form-select', data: {range_slider_value_target: "site"} %>
+          <div class="options slidecontainer" >
+            <%= form.range_field :score,  min: "0", max: "100", class: "slider", value: params[:score], step: 5, data: { action: "input->range-slider-value#showScoreFilter", range_slider_value_target: "percentageScoreRange"}%>
+            <p><span data-range-slider-value-target="percentageOutput"><%=params[:score]%></span></p>
+          </div>
         </div>
+
         <p>Time Limit</p>
         <div class="options slidecontainer" data-controller="range-slider-value">
             <%= form.range_field :time, min: "90", max: "180", class: "slider", value: params[:time], step: 5, data: { action: "change->range-slider-value#showTime", range_slider_value_target: "scoreRange"}%>


### PR DESCRIPTION
This fixes the issues with the scrollers on the advanced filters modal.

They both update as the user scrolls.

The review site is now set to whatever the params[:review_site] is, so you don't need to re-enter the site or the slider info if you want to filter by something else.